### PR TITLE
Avoid calling orjson to check for api status response

### DIFF
--- a/aiotankerkoenig/__init__.py
+++ b/aiotankerkoenig/__init__.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from .aiotankerkoenig import Tankerkoenig
+from .const import GasType, Sort, Status
 from .exceptions import (
     TankerkoenigConnectionError,
     TankerkoenigError,
     TankerkoenigInvalidKeyError,
 )
-from .models import GasType, PriceInfo, Sort, Station, Status
+from .models import PriceInfo, Station
 
 __all__ = [
     "Tankerkoenig",

--- a/aiotankerkoenig/const.py
+++ b/aiotankerkoenig/const.py
@@ -1,0 +1,27 @@
+"""Constants for the aiotankerkoenig."""
+from enum import StrEnum
+
+
+class GasType(StrEnum):
+    """Gas type."""
+
+    ALL = "all"
+    DIESEL = "diesel"
+    E5 = "e5"
+    E10 = "e10"
+
+
+class Sort(StrEnum):
+    """Sort type."""
+
+    DISTANCE = "dist"
+    PRICE = "price"
+    TIME = "time"
+
+
+class Status(StrEnum):
+    """Status type."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+    UNKNOWN = "unknown"


### PR DESCRIPTION
Avoid calling orjson directly, move the check to the `__pre_deserialize__` function of the newly introduced base response class.