### PR TITLE
Use timeout settings from ClientSession

### DIFF
--- a/aiotankerkoenig/aiotankerkoenig.py
+++ b/aiotankerkoenig/aiotankerkoenig.py
@@ -33,7 +33,6 @@ class Tankerkoenig:
 
     api_key: str
     session: ClientSession | None = None
-    request_timeout: int = 10
 
     _close_session: bool = False
 

--- a/aiotankerkoenig/aiotankerkoenig.py
+++ b/aiotankerkoenig/aiotankerkoenig.py
@@ -61,11 +61,7 @@ class Tankerkoenig:
             )
 
         try:
-            async with asyncio.timeout(self.request_timeout):
-                response = await self.session.get(
-                    url,
-                    headers=headers,
-                )
+            async with self.session.get(url,headers=headers) as response:
                 response.raise_for_status()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to tankerkoenig.de API"

--- a/aiotankerkoenig/aiotankerkoenig.py
+++ b/aiotankerkoenig/aiotankerkoenig.py
@@ -63,6 +63,8 @@ class Tankerkoenig:
         try:
             async with self.session.get(url,headers=headers) as response:
                 response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "")
+                text = await response.text()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to tankerkoenig.de API"
             raise TankerkoenigConnectionTimeoutError(
@@ -77,8 +79,6 @@ class Tankerkoenig:
             msg = "Error occurred while communicating with the tankerkoenig.de API"
             raise TankerkoenigConnectionError(msg) from exception
 
-        content_type = response.headers.get("Content-Type", "")
-        text = await response.text()
         if "application/json" not in content_type:
             msg = "Unexpected content type from tankerkoenig.de API"
             raise TankerkoenigError(

--- a/aiotankerkoenig/aiotankerkoenig.py
+++ b/aiotankerkoenig/aiotankerkoenig.py
@@ -1,7 +1,6 @@
 """Tankerkoenig API client."""
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from importlib import metadata
 import socket

--- a/aiotankerkoenig/aiotankerkoenig.py
+++ b/aiotankerkoenig/aiotankerkoenig.py
@@ -59,7 +59,7 @@ class Tankerkoenig:
             )
 
         try:
-            async with self.session.get(url,headers=headers) as response:
+            async with self.session.get(url, headers=headers) as response:
                 response.raise_for_status()
                 content_type = response.headers.get("Content-Type", "")
                 text = await response.text()

--- a/tests/test_aiotankerkoenig.py
+++ b/tests/test_aiotankerkoenig.py
@@ -1,9 +1,7 @@
 """Test the tankerkoenig API client."""
-import asyncio
-from typing import Any
 
 import aiohttp
-from aioresponses import CallbackResult, aioresponses
+from aioresponses import aioresponses
 import pytest
 from syrupy import SnapshotAssertion
 
@@ -12,7 +10,6 @@ from aiotankerkoenig import (
     Sort,
     Tankerkoenig,
     TankerkoenigConnectionError,
-    TankerkoenigConnectionTimeoutError,
     TankerkoenigError,
     TankerkoenigInvalidKeyError,
     TankerkoenigRateLimitError,
@@ -20,28 +17,6 @@ from aiotankerkoenig import (
 from tests import load_fixture
 
 TANKERKOENIG_ENDPOINT = "https://creativecommons.tankerkoenig.de"
-
-
-async def test_timeout(
-    responses: aioresponses,
-) -> None:
-    """Test request timeout."""
-
-    async def response_handler(_: str, **_kwargs: Any) -> CallbackResult:
-        """Response handler for this test."""
-        await asyncio.sleep(2)
-        return CallbackResult(body="Good morning!")
-
-    responses.get(
-        f"{TANKERKOENIG_ENDPOINT}/json/detail.php?apikey=abc123&id=1",
-        callback=response_handler,
-    )
-    async with Tankerkoenig(
-        api_key="abc123",
-        request_timeout=1,
-    ) as tankerkoenig_client:
-        with pytest.raises(TankerkoenigConnectionTimeoutError):
-            await tankerkoenig_client.station_details(station_id="1")
 
 
 async def test_unexpected_server_response(


### PR DESCRIPTION
reference: https://github.com/home-assistant/core/issues/110251

it seems that with switch to py3.12 in HA, something has changed with job queuing in asyncio. nevertheless, the `asyncio.timeout` does not only consider the job execution itself, but also the scheduling/waiting time.