### PR TITLE
stale workflow disable auto-closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,25 +19,21 @@ jobs:
         uses: actions/stale@v10.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 7
+          days-before-stale: 60
+          days-before-close: -1   # disable auto-closing
           remove-stale-when-updated: true
+
           stale-issue-label: "stale"
           exempt-issue-labels: "no-stale,help-wanted"
           stale-issue-message: >
-            There hasn't been any activity on this issue recently, so we
-            clean up some of the older and inactive issues.
+            There hasn't been any activity on this issue recently, so we clean up some of the older and inactive issues.
+            Please make sure to update to the latest version and check if that solves the issue.
+            Let us know if that works for you by leaving a comment 👍
+            This issue has now been marked as stale. Thanks!
 
-            Please make sure to update to the latest version and
-            check if that solves the issue. Let us know if that works for you
-            by leaving a comment 👍
-
-            This issue has now been marked as stale and will be closed if no
-            further activity occurs. Thanks!
           stale-pr-label: "stale"
           exempt-pr-labels: "no-stale"
           stale-pr-message: >
-            There hasn't been any activity on this pull request recently. This
-            pull request has been automatically marked as stale because of that
-            and will be closed if no further activity occurs within 7 days.
+            There hasn't been any activity on this pull request recently.
+            This pull request has been automatically marked as stale.
             Thank you for your contributions.


### PR DESCRIPTION
## Changes

- stale workflow disable auto-closing
- increase days before stale to 60 days

## Why?

Prevents spam messages to keep issue "active" avoiding stale bot related auto closing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository maintenance workflow: extended inactivity period before items are marked stale from 30 to 60 days and disabled automatic closing of stale items. Notification text for stale issues and PRs was shortened and clarified to indicate items are now "marked as stale." Minor formatting adjustments to the workflow messages were also made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->